### PR TITLE
(reversing Bug 3276 fix) HQ updating activities tagged as hq-1 will now affect the update time stamp

### DIFF
--- a/Hub.Legacy/Gcpe.Hub.Legacy.Website/Calendar/Activity.aspx.cs
+++ b/Hub.Legacy/Gcpe.Hub.Legacy.Website/Calendar/Activity.aspx.cs
@@ -1186,6 +1186,10 @@ namespace Gcpe.Hub.Calendar
                 activity.LastUpdatedBy = customPrincipal.Id;
                 activity.LastUpdatedDateTime = DateTime.Now;
             }
+            else if (customPrincipal.IsGCPEHQ && activity.LastUpdatedDateTime != null && KeywordsTextBox.Text.Contains("HQ-1"))
+            {
+                activity.LastUpdatedDateTime = activity.LastUpdatedDateTime.Value.AddSeconds(1);
+            }
 
             bool categoryHasChanged = CategoriesDropDownList.Value != CategoriesDropDownList.Items.FindByText(CurrentActiveActivity.Categories.TrimStart())?.Value;
             bool commMaterialsHaveChanged = CommMaterialsSelectedValuesServerSide.Text != CommMaterialsSelectedValues.Text;


### PR DESCRIPTION
-- reverse Bruno's changes for Bug 3276 CorpCal: Data loss when a user updates an activity after HQ 