### PR TITLE
Fixed bug for non-GCPE activities from within the activity page does not update the status to reviewed, nor log it in the history log

### DIFF
--- a/Hub.Legacy/Gcpe.Hub.Legacy.Website/Calendar/Activity.aspx.cs
+++ b/Hub.Legacy/Gcpe.Hub.Legacy.Website/Calendar/Activity.aspx.cs
@@ -1186,6 +1186,10 @@ namespace Gcpe.Hub.Calendar
                 activity.LastUpdatedBy = customPrincipal.Id;
                 activity.LastUpdatedDateTime = DateTime.Now;
             }
+            else if (customPrincipal.IsGCPEHQ && activity.LastUpdatedDateTime != null && KeywordsTextBox.Text.Contains("HQ-1"))
+            {
+                activity.LastUpdatedDateTime = activity.LastUpdatedDateTime.Value.AddSeconds(1);
+            }
 
             bool categoryHasChanged = CategoriesDropDownList.Value != CategoriesDropDownList.Items.FindByText(CurrentActiveActivity.Categories.TrimStart())?.Value;
             bool commMaterialsHaveChanged = CommMaterialsSelectedValuesServerSide.Text != CommMaterialsSelectedValues.Text;

--- a/Hub.Legacy/Gcpe.Hub.Legacy.Website/Calendar/Activity.aspx.cs
+++ b/Hub.Legacy/Gcpe.Hub.Legacy.Website/Calendar/Activity.aspx.cs
@@ -1182,14 +1182,10 @@ namespace Gcpe.Hub.Calendar
             // Meta Data (The rest of the fields are handled by the database using simple default values)
             // Don't update this info if current user is GCPEHQ Admin and the activity is not a GCPEHQ activity
             if (!customPrincipal.IsGCPEHQ || !customPrincipal.IsInRoleOrGreater(SecurityRole.Administrator) || 
-                activity.Ministry.Abbreviation == customPrincipal.GCPEHQ_Ministry || activity.LastUpdatedDateTime == null || KeywordsTextBox.Text.Contains("HQ-1"))
+                activity.Ministry.Abbreviation == customPrincipal.GCPEHQ_Ministry || activity.LastUpdatedDateTime == null)
             {
                 activity.LastUpdatedBy = customPrincipal.Id;
                 activity.LastUpdatedDateTime = DateTime.Now;
-            }
-            else if (customPrincipal.IsGCPEHQ && activity.LastUpdatedDateTime != null && KeywordsTextBox.Text.Contains("HQ-1"))
-            {
-                activity.LastUpdatedDateTime = activity.LastUpdatedDateTime.Value.AddSeconds(1);
             }
 
             bool categoryHasChanged = CategoriesDropDownList.Value != CategoriesDropDownList.Items.FindByText(CurrentActiveActivity.Categories.TrimStart())?.Value;

--- a/Hub.Legacy/Gcpe.Hub.Legacy.Website/Web.config
+++ b/Hub.Legacy/Gcpe.Hub.Legacy.Website/Web.config
@@ -28,7 +28,7 @@
   </connectionStrings>
 
   <appSettings>
-    <add key="Version" value="8.2.1" />
+    <add key="Version" value="8.2.3" />
   <!--  This setting is required by the Calendar Activity page.
     You will get an error like the following without it: $(...).tooltip is not a function  -->
     <add key="ValidationSettings:UnobtrusiveValidationMode" value="None" />


### PR DESCRIPTION
-- fixed bug 3323: Reviewing non-GCPE activities from within the activity page does not update the status to reviewed, nor log it in the history log
-- fixed bug 2918: https://dev.azure.com/gcpe/Hub/_workitems/edit/2918/